### PR TITLE
Add placeholder React app

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Web App</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="root"></div>
+  <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+  <script src="src/main.js"></script>
+</body>
+</html>

--- a/apps/web/src/main.js
+++ b/apps/web/src/main.js
@@ -1,0 +1,82 @@
+const { useState } = React;
+
+function EventForm() {
+  const [formData, setFormData] = useState({
+    name: '',
+    datetime: '',
+    location: '',
+    description: ''
+  });
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData({ ...formData, [name]: value });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    console.log(formData);
+  };
+
+  return React.createElement(
+    'form',
+    { onSubmit: handleSubmit },
+    React.createElement(
+      'label',
+      null,
+      'Event Name',
+      React.createElement('input', {
+        name: 'name',
+        value: formData.name,
+        onChange: handleChange
+      })
+    ),
+    React.createElement(
+      'label',
+      null,
+      'Date/Time',
+      React.createElement('input', {
+        type: 'datetime-local',
+        name: 'datetime',
+        value: formData.datetime,
+        onChange: handleChange
+      })
+    ),
+    React.createElement(
+      'label',
+      null,
+      'Location',
+      React.createElement('input', {
+        name: 'location',
+        value: formData.location,
+        onChange: handleChange
+      })
+    ),
+    React.createElement(
+      'label',
+      null,
+      'Description',
+      React.createElement('textarea', {
+        name: 'description',
+        value: formData.description,
+        onChange: handleChange
+      })
+    ),
+    React.createElement(
+      'button',
+      { type: 'submit' },
+      'Submit'
+    )
+  );
+}
+
+function App() {
+  return React.createElement(
+    'div',
+    null,
+    React.createElement('h1', null, 'Event Creator'),
+    React.createElement(EventForm)
+  );
+}
+
+ReactDOM.render(React.createElement(App), document.getElementById('root'));

--- a/apps/web/styles.css
+++ b/apps/web/styles.css
@@ -1,0 +1,21 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 2rem;
+}
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+label {
+  display: flex;
+  flex-direction: column;
+}
+input, textarea {
+  padding: 0.5rem;
+  font-size: 1rem;
+}
+button {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+}


### PR DESCRIPTION
## Summary
- add `apps/web` with simple React-based HTML
- include a small form for event details
- provide minimal styling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f598791b0832a8c96cf1a28dd56bf