### PR TITLE
Add Bun API scaffold

### DIFF
--- a/apps/api/bunfig.toml
+++ b/apps/api/bunfig.toml
@@ -1,0 +1,1 @@
+entrypoint = "index.ts"

--- a/apps/api/index.ts
+++ b/apps/api/index.ts
@@ -1,0 +1,28 @@
+import { MongoClient } from 'mongodb';
+
+const port = Number(process.env.PORT) || 3001;
+const mongoUri = process.env.MONGODB_URI || 'mongodb://localhost:27017';
+const dbName = process.env.DB_NAME || 'events_db';
+
+const client = new MongoClient(mongoUri);
+await client.connect();
+console.log('Connected to MongoDB');
+
+const collection = client.db(dbName).collection('events');
+
+Bun.serve({
+  port,
+  async fetch(req) {
+    const url = new URL(req.url);
+    if (req.method === 'POST' && url.pathname === '/events') {
+      const event = await req.json();
+      await collection.insertOne(event);
+      return new Response(JSON.stringify({ status: 'ok' }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    return new Response('Not Found', { status: 404 });
+  },
+});
+
+console.log(`API server listening on http://localhost:${port}`);

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "api",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "start": "bun index.ts"
+  },
+  "dependencies": {
+    "mongodb": "^5.8.0"
+  }
+}


### PR DESCRIPTION
## Summary
- set up `apps/api` with Bun
- implement POST /events endpoint storing submissions in MongoDB

## Testing
- `bun apps/api/index.ts` *(fails: Cannot find package 'mongodb')*

------
https://chatgpt.com/codex/tasks/task_e_683f5a6eed4c832aba3132fdb680160d