### PR TITLE
Handle POST submission in event form

### DIFF
--- a/apps/web/src/main.js
+++ b/apps/web/src/main.js
@@ -7,15 +7,30 @@ function EventForm() {
     location: '',
     description: ''
   });
+  const [message, setMessage] = useState('');
 
   const handleChange = (e) => {
     const { name, value } = e.target;
     setFormData({ ...formData, [name]: value });
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log(formData);
+    try {
+      const res = await fetch('/events', {
+        method: 'POST',
+        body: JSON.stringify(formData)
+      });
+      const data = await res.json();
+      if (res.ok && data.status === 'ok') {
+        setMessage('Event created successfully');
+      } else {
+        setMessage(data.error || 'Error creating event');
+      }
+    } catch (err) {
+      console.error(err);
+      setMessage('Error creating event');
+    }
   };
 
   return React.createElement(
@@ -66,7 +81,8 @@ function EventForm() {
       'button',
       { type: 'submit' },
       'Submit'
-    )
+    ),
+    message && React.createElement('p', null, message)
   );
 }
 


### PR DESCRIPTION
## Summary
- send form data to `/events` via POST request
- show server response message in the UI

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run build` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f6937db50832aa8f30a0f2b4608ca