### PR TITLE
Add event prompt generation

### DIFF
--- a/apps/api/index.ts
+++ b/apps/api/index.ts
@@ -1,4 +1,5 @@
 import { MongoClient } from 'mongodb';
+import { buildEventPrompt } from '../../libs/event-helpers';
 
 const port = Number(process.env.PORT) || 3001;
 const mongoUri = process.env.MONGODB_URI || 'mongodb://localhost:27017';
@@ -16,8 +17,10 @@ Bun.serve({
     const url = new URL(req.url);
     if (req.method === 'POST' && url.pathname === '/events') {
       const event = await req.json();
-      await collection.insertOne(event);
-      return new Response(JSON.stringify({ status: 'ok' }), {
+      const prompt = await buildEventPrompt(event);
+      const doc = { ...event, prompt };
+      await collection.insertOne(doc);
+      return new Response(JSON.stringify({ status: 'ok', prompt }), {
         headers: { 'Content-Type': 'application/json' },
       });
     }


### PR DESCRIPTION
## Summary
- add `buildEventPrompt` usage in API

## Testing
- `bun apps/api/index.ts` *(fails: Cannot find package 'mongodb')*

------
https://chatgpt.com/codex/tasks/task_e_683f6a150e4c832a8705929b8bb9d440