### PR TITLE
Add linting and testing setup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "env": {
+    "node": true,
+    "es2020": true
+  },
+  "extends": ["eslint:recommended", "prettier"],
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module"
+  },
+  "ignorePatterns": ["dist/**"],
+  "rules": {}
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "es5"
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,16 @@
+import js from '@eslint/js';
+import prettier from 'eslint-config-prettier';
+
+export default [
+  js.configs.recommended,
+  prettier,
+  {
+    files: ['**/*.ts'],
+    ignores: ['dist/**'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+    },
+    rules: {},
+  },
+];

--- a/libs/event-helpers/project.json
+++ b/libs/event-helpers/project.json
@@ -16,6 +16,20 @@
         "command": "bun run index.ts",
         "cwd": "libs/event-helpers"
       }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "eslint . --ext .ts",
+        "cwd": "libs/event-helpers"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "bunx vitest",
+        "cwd": "libs/event-helpers"
+      }
     }
   }
 }

--- a/libs/event-helpers/test/index.test.ts
+++ b/libs/event-helpers/test/index.test.ts
@@ -1,0 +1,8 @@
+import { buildEventPrompt } from '../index';
+import { describe, it, expect } from 'vitest';
+
+describe('buildEventPrompt', () => {
+  it('is a function', () => {
+    expect(typeof buildEventPrompt).toBe('function');
+  });
+});

--- a/libs/event-helpers/vitest.config.ts
+++ b/libs/event-helpers/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});

--- a/nx.json
+++ b/nx.json
@@ -7,7 +7,7 @@
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": []
+        "cacheableOperations": ["lint", "test"]
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
-    "nx": "latest"
+    "nx": "latest",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "prettier": "^3.1.0",
+    "vitest": "^1.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add ESLint and Prettier configs to repository root
- configure vitest for `event-helpers`
- define Nx `lint` and `test` targets
- record dev dependencies

## Testing
- `bun x vitest run --dir libs/event-helpers` *(fails: GET https://registry.npmjs.org/vitest - 403)*
- `npx eslint libs/event-helpers --ext .ts` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f6f890714832ab4ac5e1b5438677a