### PR TITLE
Update gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 node_modules
 .DS_Store
+dist/
+bun.lockb
+.env
+coverage/
+tmp/


### PR DESCRIPTION
## Summary
- ignore typical build and Nx output directories

## Testing
- `npx nx --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f746fce64832a9806887d9619329c